### PR TITLE
Grouped fixes for 0.1 (12/07)

### DIFF
--- a/modules_sources/antenna/prices/MarketerDirectSale.ts
+++ b/modules_sources/antenna/prices/MarketerDirectSale.ts
@@ -14,7 +14,7 @@ export const MarketerDirectSale = async (sale: any, event: any, sale_contract_ty
 
             const ether_price = new PriceModel({
                 currency: 'ether',
-                value: price,
+                value: price.toString(),
                 sale: sale.id
             });
 

--- a/modules_sources/antenna/prices/MarketerTester.ts
+++ b/modules_sources/antenna/prices/MarketerTester.ts
@@ -14,7 +14,7 @@ export const MarketerTester = async (sale: any, event: any, sale_contract_type: 
 
             const ether_price = new PriceModel({
                 currency: 'ether',
-                value: price,
+                value: price.toString(),
                 sale: sale.id
             });
 


### PR DESCRIPTION
- Method calls now return BigNumbers. Use toString to get prices as
decimal strings